### PR TITLE
Add an option to ignore specific terms

### DIFF
--- a/lib/equality.js
+++ b/lib/equality.js
@@ -174,6 +174,9 @@ function check(expression, parent, position) {
     var result;
 
     for (phrase in values) {
+        if (phrase in equality.config.ignoreTerms) {
+            continue;
+        }
         result = matches(phrase, parent, position);
 
         if (result) {
@@ -573,6 +576,15 @@ function transformer(cst, file) {
 function attacher() {
     return transformer;
 }
+
+/**
+ * Config.
+ *
+ */
+var equality = attacher;
+equality.config = {
+    ignoreTerms: {}
+};
 
 /*
  * Expose.

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,27 @@ retext().use(equality).process(doc, function (err, file) {
 });
 ```
 
+### Adding exceptions
+
+```js
+var retext = require('retext');
+var equality = require('retext-equality');
+var doc = 'The process running on the host will pop a job off the queue.';
+
+equality.config.ignoreTerms = {
+    host: 'a computer server',
+    pop: 'operating on a data structure'
+};
+
+retext().use(equality).process(doc, function (err, file) {
+    if (err) throw err;
+    console.log(file.messages.map(String));
+    /*
+     * []
+     */
+});
+```
+
 ## API
 
 ### [retext](https://github.com/wooorm/retext/tree/feature/stable#api).[use](https://github.com/wooorm/retext/tree/feature/stable#retextuseplugin-options)(equality)

--- a/test.js
+++ b/test.js
@@ -339,3 +339,28 @@ describe('Phrasing', function () {
         });
     });
 });
+
+describe('ignoreTerms', function () {
+    it('should skip terms explicitly ignored', function () {
+        equality.config.ignoreTerms = {
+            host: 'a computer server',
+            pop: 'operating on a data structure'
+        };
+
+        var messages = process('The process running on the remote host will pop a job off the queue.');
+
+        dequal(messages, []);
+    });
+
+    it('should still warn about terms not ignored', function () {
+        equality.config.ignoreTerms = {
+            pop: 'operating on a data structure'
+        };
+
+        var messages = process('The process running on the remote host will pop a job off the queue.');
+
+        dequal(messages, [
+            '1:35-1:39: `host` may be insensitive, use `presenter`, `entertainer` instead'
+        ]);
+    });
+});


### PR DESCRIPTION
This allows specifically ignoring certain terms by doing e.g.

```js
equality.config.ignoreTerms = {
    host: 'a computer server',
    pop: 'operating on a data structure'
};
```

I have some misgivings about this particular manner of configuration (reaching in and modifying an object in-place) but it seems like the simplest way to do this without changing the API at all and maintaining backwards compatibility. Other options include:

  - `equality.ignoreTerms(["host", "pop"])` would add the words to the local ignore table
  - `equality({ ignoreTerms: ["host", "pop"] })` would return an attacher with configuration (this would change `equality` much more significantly, but allow different instances of attachers to have different options, which seems desirable but maybe more trouble than it's worth)

I'm open to any other way to attach options. Also it may be desirable to remove the terms from the patterns and lookup tables, rather than simply ignoring them in `check()`, but this was by far the easiest and least invasive way of doing it, and the performance downsides (given we're doing a lookup on an object) seem minimal