### PR TITLE
Update patterns.json

### DIFF
--- a/lib/patterns.json
+++ b/lib/patterns.json
@@ -3222,7 +3222,11 @@
     },
     "inconsiderate": {
       "manhour": "male",
-      "man hour": "male"
+      "manhours": "male",
+      "man hour": "male",
+      "man hours": "male",
+      "man-hour": "male",
+      "man-hours": "male"
     }
   },
   {


### PR DESCRIPTION
Google, Wikipedia, and Merriam-Webster all seem to suggest this term includes a hyphen. I use retext-mapbox-standard but noticed it includes retext-equality, so I came here for the changes. I added all the plurals because upon testing it seems they're not picked up?