### PR TITLE
Add delirious to ablist.yml

### DIFF
--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -58,6 +58,7 @@
     - batshit
     - psycho
     - crazy
+    - delirious
     - insane
     - insanity
     - loony


### PR DESCRIPTION
As per [#163](https://github.com/wooorm/alex/issues/163) in Alex, I added delirious to the list of words that are ablist. 